### PR TITLE
ArtifactCreator leaks filesystem handles

### DIFF
--- a/src/main/java/org/mule/tooling/maven/test/repository/ArtifactCreator.java
+++ b/src/main/java/org/mule/tooling/maven/test/repository/ArtifactCreator.java
@@ -79,7 +79,9 @@ public class ArtifactCreator {
         File artifactFile = getFile(repositoryFolder, type);
         artifactFile.createNewFile();
       }
-      new MavenXpp3Writer().write(new FileWriter(pomFile), model);
+      try (Writer fileWriter = new FileWriter(pomFile)) { 
+          new MavenXpp3Writer().write(fileWriter, model);
+      }
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/org/mule/tooling/maven/test/repository/ArtifactCreator.java
+++ b/src/main/java/org/mule/tooling/maven/test/repository/ArtifactCreator.java
@@ -79,7 +79,7 @@ public class ArtifactCreator {
         File artifactFile = getFile(repositoryFolder, type);
         artifactFile.createNewFile();
       }
-      try (Writer fileWriter = new FileWriter(pomFile)) { 
+      try (FileWriter fileWriter = new FileWriter(pomFile)) { 
           new MavenXpp3Writer().write(fileWriter, model);
       }
     } catch (IOException e) {


### PR DESCRIPTION
MavenXpp3Writer().write() does not close the writer passed in, so it is up to the caller to do it. Failure to do so leads to any files created not being deletable on Windows.